### PR TITLE
remove the transparent effect from the fixed top navbar

### DIFF
--- a/resources/assets/sass/_website.scss
+++ b/resources/assets/sass/_website.scss
@@ -27,7 +27,7 @@ body {
 }
 
 .navbar-default {
-    background-color: rgba(255,255,255,0.8);
+    background-color: rgba(255,255,255);
     border-color: #e7e7e7;
 
     .navbar-nav {
@@ -46,8 +46,8 @@ body {
     	.active > a:hover {
 			color: #fff;
 	    	background-color: #5cb7ca;
-    	} 
-    } 
+    	}
+    }
 }
 
 .schedule-box {
@@ -64,7 +64,7 @@ body {
 
 footer {
 	color: $footer-text-color;
-	background: $footer-color; 
+	background: $footer-color;
 	margin-top: 20px;
 	margin-bottom:0;
 	min-height: 5em;
@@ -78,12 +78,12 @@ footer {
 
 	li {
 		float: left;
-		margin-right: 10px; 
+		margin-right: 10px;
 
 		a {
 			color: $footer-link-color;
 
-			&:hover, 
+			&:hover,
 			&:focus {
 				text-decoration: none;
 				background-color: none;


### PR DESCRIPTION
before:
when the opacity is applied to 0.8, the content beneath the top fixed navbar is surface making the experience not good

![before-nav-mobile-version](https://cloud.githubusercontent.com/assets/863947/21770904/decf8eba-d6b7-11e6-8711-32ff5dcf7817.png)

![before-desktop-version-nav](https://cloud.githubusercontent.com/assets/863947/21770905/deffb180-d6b7-11e6-8034-b370aa347444.png)


after:
when the opacity is removed, the content beneath the top fixed navbar no longer visible and making the separation between navbar and content section clear.

![after-desktop-version-nav](https://cloud.githubusercontent.com/assets/863947/21770917/e6c37910-d6b7-11e6-96e6-cdc46292a38a.png)

![after-nav-mobile-version](https://cloud.githubusercontent.com/assets/863947/21770918/e6f3523e-d6b7-11e6-9b50-640211c611d6.png)
